### PR TITLE
Add CodeCacheFlushing

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,1 +1,3 @@
 -J-Xmx2g
+-J-XX:+UseCodeCacheFlushing
+-J-XX:ReservedCodeCacheSize=128m


### PR DESCRIPTION
During compilation the JVM code cache gets full. (Makes compilation slower but will still work). Add CodeCacheFlushing and increase CodeCacheSize to avoid this problem.

CodeCache: size=131072Kb used=123244Kb max_used=123302Kb free=7827Kb
 bounds [0x00007f8b3f592000, 0x00007f8b47592000, 0x00007f8b47592000]
 total_blobs=31894 nmethods=31337 adapters=456
 compilation: disabled (not enough contiguous free space left)
OpenJDK 64-Bit Server VM warning: CodeCache is full. Compiler has been disabled.
OpenJDK 64-Bit Server VM warning: Try increasing the code cache size using -XX:ReservedCodeCacheSize=