### PR TITLE
OO_New_version_swissqrcode_has_new_string_for_iban_non_ch

### DIFF
--- a/src/main/scala/ch/openolitor/buchhaltung/reporting/RechnungReportData.scala
+++ b/src/main/scala/ch/openolitor/buchhaltung/reporting/RechnungReportData.scala
@@ -139,7 +139,7 @@ trait RechnungReportData extends AsyncConnectionPoolContextAware with Buchhaltun
               val message: String = listValidation.asScala.map { m =>
                 m.getMessageKey: String
               }.mkString("")
-              if (message.equals("account_is_ch_li_iban")) {
+              if (message.equals("account_iban_not_from_ch_or_li")) {
                 logger.warn(s"Bei der QR-Code-Validierung wurde festgestellt, dass die IBAN nicht aus der Schweiz oder Liechtenstein stammt")
                 s""
               } else {


### PR DESCRIPTION
New version of the swissqrcode fixes the misleading string for non ch iban by this new one "account_iban_not_from_ch_or_li"